### PR TITLE
ci: add MSYS2 recipe and msys-* workflow jobs

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -234,7 +234,7 @@ jobs:
     - name: '🚧 Build'
       run: |
         cd msys2
-        makepkg-mingw --noconfirm --noprogressbar -sCLf --nocheck
+        makepkg-mingw --noconfirm --noprogressbar -sCLf
       env:
         MINGW_INSTALLS: ${{ matrix.msystem }}
 

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -196,3 +196,92 @@ jobs:
       with:
         name: ${{env.EXECUTABLE}}-${{env.VERSION}}-Windows.exe
         path: deploy/windows/nsis/${{env.EXECUTABLE}}-${{env.VERSION}}-Windows.exe
+
+
+  # Windows MSYS2 build
+  msys2-makepkg:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { icon: '🟪', msystem: MINGW64, arch: x86_64 }
+          - { icon: '🟦', msystem: MINGW32, arch: i686   }
+    name:  ${{ matrix.icon }} ${{ matrix.msystem }} | ${{ matrix.arch }} | makepkg
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - run: git config --global core.autocrlf input
+      shell: bash
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: '${{ matrix.icon }} Setup MSYS2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        update: true
+        install: >
+          base-devel
+          mingw-w64-${{ matrix.arch }}-toolchain
+
+    - name: '🚧 Build'
+      run: |
+        cd msys2
+        makepkg-mingw --noconfirm --noprogressbar -sCLf --nocheck
+      env:
+        MINGW_INSTALLS: ${{ matrix.msystem }}
+
+    - name: '📤 Upload artifact: MSYS2 ${{ matrix.arch }} package'
+      uses: actions/upload-artifact@v2
+      with:
+        name: msys2-pkgs
+        path: msys2/*.zst
+
+  # Test Windows MSYS2 packages
+  msys2-test:
+    needs: msys2-makepkg
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { icon: '🟪', msystem: MINGW64, arch: x86_64 }
+          - { icon: '🟦', msystem: MINGW32, arch: i686   }
+    name: ${{ matrix.icon }} ${{ matrix.msystem }} | ${{ matrix.arch }} | Test
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - name: '${{ matrix.icon }} Setup MSYS2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        update: true
+        install: >
+          tree
+          tar
+          zstd
+
+    - name: '📥 Download artifacts: MSYS2 packages'
+      uses: actions/download-artifact@v2
+      with:
+        name: msys2-pkgs
+
+    - name: 'Install MSYS2 package'
+      run: |
+        pacman -U --noconfirm --noprogressbar *${{ matrix.arch }}*.zst
+
+    - name: 'List contents of package'
+      run: |
+        mkdir tmp
+        cd tmp
+        /usr/bin/tar xf ../*${{ matrix.arch }}*.zst
+        tree ${{ matrix.msystem }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -234,7 +234,12 @@ jobs:
     - name: '🚧 Build'
       run: |
         cd msys2
-        makepkg-mingw --noconfirm --noprogressbar -sCLf
+        tries=0
+        # Try building three times due to the arbitrary 'Bad address' error
+        while [ $tries -lt 3 ]; do
+          makepkg-mingw --noconfirm --noprogressbar -sCLf && break || tries=$((tries+1))
+        done
+
       env:
         MINGW_INSTALLS: ${{ matrix.msystem }}
 

--- a/msys2/PKGBUILD
+++ b/msys2/PKGBUILD
@@ -1,0 +1,36 @@
+_realname=serial-studio
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=ci
+pkgrel=1
+pkgdesc="Serial Studio: Multi-purpose serial data visualization & processing program (mingw-w64)"
+arch=('any')
+url="https://github.com/Serial-Studio/Serial-Studio"
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-qt5")
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+)
+
+source=()
+sha256sums=()
+
+prepare () {
+  mkdir -p "${srcdir}"/build
+}
+
+build() {
+  cd "${srcdir}"/build
+  MSYS2_ARG_CONV_EXCL="PREFIX=" qmake PREFIX="${MINGW_PREFIX}" ../../..
+  make
+}
+
+check() {
+  "${srcdir}"/build/release/SerialStudio.exe --version
+}
+
+package() {
+  cd "${srcdir}"/build
+  make INSTALL_ROOT="${pkgdir}" install
+}


### PR DESCRIPTION
Ref #6

This is for showcasing an MSYS2 recipe which builds `master` on MINGW32 and MINGW64, and produces nightly artifacts. Each of the artifacts is installed and tested in a separated job, for ensuring that the metadata in the package is correct and, therefore, dependencies are installed automatically. This recipe is slightly different from the on upstreamed to MSYS2 repositories, because that one builds a fixed version of Serial-Studio, not `master`.

BTW, I did some "fancy" enhancements to the existing job. I replaced comments with emojis/icons, which allow understanding the workflow easier, both in sources and in the Actions tab. You might want to pick those, independently from the MSYS2 jobs.

It took several (18) tries to have this tested, because of the following reasons:

- When the branch was based on v1.0.9, installation of Qt5 would fail on the current three jobs. It was a problem when retrieving it, so I don't think it's related to the codebase here. When I rebased on top of master, I saw that caching was added. Maybe that solved the problem.

- Building Serial-Studio on MSYS2 fails arbitrarily with a `make[1]: /D/a/_temp/msys/msys64/mingw32/bin/qmlcachegen.exe: Bad address` error. Restarting the CI run can solve it. However, since two jobs are built in parallel, the probability of one failing is increased. When any of them fails, the testing jobs are not executed. This is the main reason for me not to recommend merging this PR as is. I created it for iterating faster when dealing with #6. Should you be interested in having this feature merged (for providing nightly packages), we can discuss how to handle it.

- The makepkg-mingw command is executed with `--nocheck` because it seems that Serial-Studio is always started in GUI mode. It is not possible to execute `SerialSetudio --version` or `SerialStudio --help` for testing that the binary is correct, without having an screen/monitor. As an alternative, in this PR the contents of the package are listed with `tree`.

- When executing makepkg-mingw locally, without `--nocheck`, the `check` step of the recipe will start Serial-Studio. It is unfortunate that the "Version X of Serial Studio has been released" alert/message is shown, because that doesn't make sense in the context of MSYS2. MSYS2 packages are system packages, and users are expected to update them through pacman. Suggesting to download the new version is misleading because the releases are build with a different compiler and are not packages. It would be desirable if that feature was disabled optionally at build time.

- I added workflow_dispatch to the allowed events in the workflow, to allow starting it from the web GUI.
