### PR TITLE
Update Serial.cpp

### DIFF
--- a/src/IO/Drivers/Serial.cpp
+++ b/src/IO/Drivers/Serial.cpp
@@ -633,7 +633,10 @@ void IO::Drivers::Serial::refreshSerialDevices()
   Q_FOREACH (QSerialPortInfo info, validPortList)
   {
     if (!info.isNull())
-      ports.append(info.portName());
+    {
+      QString p = info.portName() + "  " + info.description();
+      ports.append(p);
+    }
   }
 
   // Update list only if necessary


### PR DESCRIPTION
Add serial port friendly name display.
When I am using a USB to multi serial chip, I believe it is necessary to display a serial port friendly name.
such as the following software:
![f88e0df2270bb8a04621b2a2b2efca8](https://github.com/Serial-Studio/Serial-Studio/assets/78026992/ac839ea6-0e2f-47d1-832b-a26af7a66b2b)
