### PR TITLE
refactor: use QStandardPaths for file locations

### DIFF
--- a/app/src/CSV/Export.cpp
+++ b/app/src/CSV/Export.cpp
@@ -27,6 +27,7 @@
 #include <QFileInfo>
 #include <QApplication>
 #include <QDesktopServices>
+#include <QStandardPaths>
 
 #include "IO/Manager.h"
 #include "UI/Dashboard.h"
@@ -206,8 +207,8 @@ CSV::Export::createCsvFile(const CSV::TimestampFrame &frame)
       = rxTime.toString(QStringLiteral("yyyy_MMM_dd HH_mm_ss")) + ".csv";
 
   // Get path
-  const QString path = QStringLiteral("%1/Documents/%2/CSV/%3/")
-                           .arg(QDir::homePath(),
+  const QString path = QStringLiteral("%1/%2/CSV/%3/")
+                           .arg(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
                                 qApp->applicationDisplayName(), data.title());
 
   // Generate file path if required

--- a/app/src/CSV/Player.cpp
+++ b/app/src/CSV/Player.cpp
@@ -27,6 +27,7 @@
 #include <QFileDialog>
 #include <QInputDialog>
 #include <QApplication>
+#include <QStandardPaths>
 
 #include <qtcsv/reader.h>
 #include <qtcsv/stringdata.h>
@@ -121,8 +122,9 @@ QString CSV::Player::filename() const
 QString CSV::Player::csvFilesPath() const
 {
   // Get file name and path
-  const auto path = QStringLiteral("%1/Documents/%2/CSV/")
-                        .arg(QDir::homePath(), qApp->applicationDisplayName());
+  const auto path = QStringLiteral("%1/%2/CSV/")
+                        .arg(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
+                          qApp->applicationDisplayName());
 
   // Generate file path if required
   QDir dir(path);

--- a/app/src/JSON/ProjectModel.cpp
+++ b/app/src/JSON/ProjectModel.cpp
@@ -319,9 +319,9 @@ QString JSON::ProjectModel::jsonProjectsPath() const
 {
   // Get file name and path
   static QString path
-      = QString("%1/Documents/%2/JSON Projects/")
-            .arg(QDir::homePath(), qApp->applicationDisplayName());
-
+      = QString("%1/%2/JSON Projects/")
+            .arg(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
+              qApp->applicationDisplayName());
   // Generate file path if required
   QDir dir(path);
   if (!dir.exists())

--- a/lib/QSimpleUpdater/src/Downloader.cpp
+++ b/lib/QSimpleUpdater/src/Downloader.cpp
@@ -30,6 +30,7 @@
 #include <QNetworkAccessManager>
 
 #include <math.h>
+#include <QStandardPaths>
 
 #include "Downloader.h"
 
@@ -52,7 +53,7 @@ Downloader::Downloader(QWidget *parent)
   m_mandatoryUpdate = false;
 
   /* Set download directory */
-  m_downloadDir.setPath(QDir::homePath() + "/Downloads/");
+  m_downloadDir.setPath(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation));
 
   /* Make the window look like a modal dialog */
   setWindowIcon(QIcon());


### PR DESCRIPTION
Enhance cross-platform compatibility and ensure files are saved in standard user directories by using QStandardPaths.