### PR TITLE
Bug Report and Fix: every 81th byte dropped in a frame

### DIFF
--- a/app/src/IO/Console.cpp
+++ b/app/src/IO/Console.cpp
@@ -695,13 +695,12 @@ QString IO::Console::hexadecimalStr(const QByteArray &data)
   // Convert data to string with dump every ~80 chars
   QString str;
   const int characters = 80;
-  for (int i = 0; i < copy.length(); ++i)
+  for (int i = 0; i < copy.length(); i += characters)
   {
     QByteArray line;
     for (int j = 0; j < qMin(characters, copy.length() - i); ++j)
       line.append(copy.at(i + j));
 
-    i += characters;
     str.append(HexDump(line.data(), line.size()));
   }
 


### PR DESCRIPTION
Hi,

Thank you for developing such a fantastic tool! While your software is designed primary for continuosly incoming data, I’ve been using it to control an oscilloscope via a serial connection. In this application, the data frames can become quite large. They are basically a snapshot of the oszilloscope data.

During my work, I discovered a small bug: every 81st byte was missing in the output. I’ve created a fix for this issue and would like to share it with you.

Please let me know if you’d like me to provide further details or submit the fix in a specific way.

Thanks again for your great work!

Best regards,
Bernd
