### PR TITLE
fix(Flathub): update id of metainfo.xml

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -407,7 +407,7 @@ elseif(UNIX)
   )
 
   install(
-    FILES ${CMAKE_CURRENT_SOURCE_DIR}/deploy/linux/io.github.serial_studio.Serial_Studio.metainfo.xml
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/deploy/linux/serial-studio.metainfo.xml
     DESTINATION share/metainfo
   )
 

--- a/app/deploy/linux/serial-studio.metainfo.xml
+++ b/app/deploy/linux/serial-studio.metainfo.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>io.github.serial_studio.Serial_Studio</id>
+  <id>com.serial_studio.Serial-Studio</id>
   <name>Serial Studio</name>
   <project_license>GPLv3 and Commercial License</project_license>
-  <developer id="io.github.serial-studio">
+  <developer id="com.serial-studio">
   <name>Serial Studio</name>
   </developer>
   <summary>The universal dashboard for embedded systems</summary>
   <metadata_license>CC-BY-SA-4.0</metadata_license>
-  <launchable type="desktop-id">io.github.serial_studio.Serial_Studio.desktop</launchable>
+  <launchable type="desktop-id">com.serial_studio.Serial-Studio.desktop</launchable>
   <url type="homepage">https://serial-studio.com/</url>
   <url type="bugtracker">https://github.com/Serial-Studio/Serial-Studio/issues</url>
   <url type="help">https://github.com/Serial-Studio/Serial-Studio/wiki</url>


### PR DESCRIPTION
fix error that `url` cannot be reachable

```
+ flatpak-builder-lint --exceptions manifest io.github.serial_studio.Serial_Studio.yaml
{
    "errors": [
        "appid-url-not-reachable"
    ],
    "info": [
        "appid-url-not-reachable: Tried https://github.com/serial-studio/serial_studio"
    ],
    "message": "Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter"
}
error: Recipe `validate-manifest` failed with exit code 1
```