### PR TITLE
fix(fft): prevent integer overflow in normalization factor calculation

### DIFF
--- a/app/src/UI/Widgets/FFTPlot.cpp
+++ b/app/src/UI/Widgets/FFTPlot.cpp
@@ -342,7 +342,7 @@ void Widgets::FFTPlot::updateData()
     dbCache.resize(spectrumSize);
 
   // Precompute dB values
-  const float normFactor = static_cast<float>(m_size * m_size);
+  const float normFactor = static_cast<float>(m_size) * static_cast<float>(m_size);
   for (int i = 0; i < spectrumSize; ++i)
   {
     const float re = m_fftOutput[i].r;


### PR DESCRIPTION
## Summary
- Fixes critical integer overflow bug in FFT normalization calculation
- Prevents incorrect FFT magnitude values for large FFT sizes (> 46340)

## Issue
For FFT sizes larger than ~46340 (sqrt of INT_MAX), the calculation `m_size * m_size` overflows before being cast to float, resulting in undefined behavior and incorrect normalization factors.

**Affected code:**
```cpp
// Before (line 345)
const float normFactor = static_cast<float>(m_size * m_size); // Overflow!
```

## Solution
Cast each operand to float before multiplication to ensure the calculation is performed in floating-point arithmetic:

```cpp
// After
const float normFactor = static_cast<float>(m_size) * static_cast<float>(m_size);
```

## Impact
- **Severity:** Critical
- **Fixes:** Incorrect FFT magnitudes for large FFT sizes
- **Prevents:** Undefined behavior from integer overflow
- **Ensures:** Accurate spectral analysis across all FFT size ranges

## Test Plan
- [ ] Verify FFT calculations with small sizes (< 1000) remain correct
- [ ] Test with large FFT sizes (50000, 100000) to verify no overflow
- [ ] Confirm FFT magnitude values are within expected ranges
- [ ] Run existing FFT widget tests if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)