### PR TITLE
fix: add null pointer and bounds checking to prevent crashes

### DIFF
--- a/app/src/IO/Manager.cpp
+++ b/app/src/IO/Manager.cpp
@@ -88,8 +88,11 @@ IO::Manager::~Manager()
   if (m_frameReader)
   {
     m_frameReader->disconnect();
-    QObject::disconnect(driver(), &IO::HAL_Driver::dataReceived, m_frameReader,
-                        &IO::FrameReader::processData);
+    if (driver())
+    {
+      QObject::disconnect(driver(), &IO::HAL_Driver::dataReceived, m_frameReader,
+                          &IO::FrameReader::processData);
+    }
 
     QMetaObject::invokeMethod(m_frameReader, "deleteLater",
                               Qt::QueuedConnection);
@@ -702,8 +705,11 @@ void IO::Manager::killFrameReader()
   if (m_frameReader)
   {
     m_frameReader->disconnect();
-    QObject::disconnect(driver(), &IO::HAL_Driver::dataReceived, m_frameReader,
-                        &IO::FrameReader::processData);
+    if (driver())
+    {
+      QObject::disconnect(driver(), &IO::HAL_Driver::dataReceived, m_frameReader,
+                          &IO::FrameReader::processData);
+    }
 
     QMetaObject::invokeMethod(m_frameReader, &QObject::deleteLater,
                               Qt::QueuedConnection);

--- a/app/src/UI/Dashboard.cpp
+++ b/app/src/UI/Dashboard.cpp
@@ -159,7 +159,7 @@ double UI::Dashboard::smartInterval(const double min, const double max,
 
   // Ensure the interval divides the range
   const double remainder = std::fmod(range, step);
-  if (remainder != 0.0)
+  if (step > 0.0 && remainder != 0.0)
     step = range / std::ceil(range / step);
 
   // Return obtained step size

--- a/app/src/UI/Widgets/FFTPlot.cpp
+++ b/app/src/UI/Widgets/FFTPlot.cpp
@@ -112,6 +112,11 @@ Widgets::FFTPlot::FFTPlot(const int index, QQuickItem *parent)
 
     // Create FFT plan
     m_plan = kiss_fft_alloc(m_size, 0, nullptr, nullptr);
+    if (!m_plan)
+    {
+      qWarning() << "FFT plan allocation failed for size:" << m_size;
+      return;
+    }
 
     // Obtain minimum and maximum values
     double minVal = dataset.fftMin;
@@ -306,6 +311,11 @@ void Widgets::FFTPlot::updateData()
     }
 
     m_plan = kiss_fft_alloc(m_size, 0, nullptr, nullptr);
+    if (!m_plan)
+    {
+      qWarning() << "FFT plan allocation failed for size:" << m_size;
+      return;
+    }
   }
 
   // Access the internal buffer and state of the circular queue

--- a/app/src/UI/Widgets/Plot.cpp
+++ b/app/src/UI/Widgets/Plot.cpp
@@ -271,12 +271,17 @@ void Widgets::Plot::updateData()
       std::size_t yIdx = Y.frontIndex();
 
       // Update plot data points, avoid queue operations overhead
-      for (qsizetype i = 0; i < count; ++i)
+      const auto xCapacity = X.capacity();
+      const auto yCapacity = Y.capacity();
+      if (xCapacity > 0 && yCapacity > 0)
       {
-        out[i].setX(xData[xIdx]);
-        out[i].setY(yData[yIdx]);
-        xIdx = (xIdx + 1) % X.capacity();
-        yIdx = (yIdx + 1) % Y.capacity();
+        for (qsizetype i = 0; i < count; ++i)
+        {
+          out[i].setX(xData[xIdx]);
+          out[i].setY(yData[yIdx]);
+          xIdx = (xIdx + 1) % xCapacity;
+          yIdx = (yIdx + 1) % yCapacity;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds defensive null pointer and bounds checking across multiple components
- Prevents crashes during shutdown, division by zero, and resource allocation failures

## Issues Fixed

### 1. Null Pointer Access in IO::Manager (High Severity)
**Files:** `app/src/IO/Manager.cpp:91-92, 708-709`

**Issue:** Direct access to `driver()` without null check during cleanup could crash if driver is null.

**Fix:** Added null check before disconnecting signals:
```cpp
if (driver())
{
  QObject::disconnect(driver(), &IO::HAL_Driver::dataReceived, ...);
}
```

### 2. Division by Zero in Dashboard (High Severity)
**File:** `app/src/UI/Dashboard.cpp:162-163`

**Issue:** No validation that `step > 0` before division:
```cpp
// Before
if (remainder != 0.0)
    step = range / std::ceil(range / step);  // Division by zero if step == 0
```

**Fix:** Added step validation:
```cpp
if (step > 0.0 && remainder != 0.0)
    step = range / std::ceil(range / step);
```

### 3. Modulo by Zero in Plot Widget (High Severity)
**File:** `app/src/UI/Widgets/Plot.cpp:278-279`

**Issue:** No bounds check before modulo operation with queue capacity:
```cpp
xIdx = (xIdx + 1) % X.capacity();  // Undefined if capacity() returns 0
```

**Fix:** Cache capacity and validate before loop:
```cpp
const auto xCapacity = X.capacity();
const auto yCapacity = Y.capacity();
if (xCapacity > 0 && yCapacity > 0)
{
  // Safe modulo operations
}
```

### 4. Missing Null Check After FFT Allocation (Medium Severity)
**File:** `app/src/UI/Widgets/FFTPlot.cpp:114, 313`

**Issue:** No validation after `kiss_fft_alloc()` which can return nullptr for large sizes:
```cpp
m_plan = kiss_fft_alloc(m_size, 0, nullptr, nullptr);
// No null check, proceeds to use m_plan
```

**Fix:** Added null checks with error logging:
```cpp
m_plan = kiss_fft_alloc(m_size, 0, nullptr, nullptr);
if (!m_plan)
{
  qWarning() << "FFT plan allocation failed for size:" << m_size;
  return;
}
```

## Impact
- **Crash Prevention:** Eliminates crashes during shutdown when driver is null
- **Math Safety:** Prevents division/modulo by zero in calculations
- **Graceful Degradation:** Handles allocation failures instead of crashing
- **Stability:** Improves overall application robustness in edge cases

## Test Plan
- [ ] Test shutdown sequence with and without active driver
- [ ] Test dashboard rendering with various axis range configurations
- [ ] Test plot widget with empty data queues
- [ ] Test FFT widget with very large FFT sizes (>100000)
- [ ] Verify no regressions in normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)