### PR TITLE
Add ANSI color support to terminal widget

### DIFF
--- a/app/qml/MainWindow/Panes/Console.qml
+++ b/app/qml/MainWindow/Panes/Console.qml
@@ -38,6 +38,7 @@ Widgets.Pane {
   // Custom properties
   //
   property alias vt100emulation: terminal.vt100emulation
+  property alias ansiColors: terminal.ansiColors
 
   //
   // Utility functions between terminal widget & main window

--- a/app/qml/Widgets/Dashboard/Terminal.qml
+++ b/app/qml/Widgets/Dashboard/Terminal.qml
@@ -31,6 +31,7 @@ Item {
   implicitWidth: layout.implicitWidth + 32
   implicitHeight: layout.implicitHeight + 32
   property alias vt100emulation: terminal.vt100emulation
+  property alias ansiColors: terminal.ansiColors
 
   //
   // Widget data inputs (unused)
@@ -65,6 +66,7 @@ Item {
     property alias timestamp: timestampCheck.checked
     property alias checksum: checkumCombo.currentIndex
     property alias vt100Enabled: terminal.vt100emulation
+    property alias ansiColorsEnabled: terminal.ansiColors
     property alias lineEnding: lineEndingCombo.currentIndex
     property alias displayMode: displayModeCombo.currentIndex
   }
@@ -400,6 +402,17 @@ Item {
         onCheckedChanged: {
           if (terminal.vt100emulation !== checked)
             terminal.vt100emulation = checked
+        }
+      }
+
+      CheckBox {
+        id: ansiColorsCheck
+        text: qsTr("ANSI Colors")
+        Layout.alignment: Qt.AlignVCenter
+        checked: terminal.ansiColors
+        onCheckedChanged: {
+          if (terminal.ansiColors !== checked)
+            terminal.ansiColors = checked
         }
       }
 

--- a/app/src/UI/Widgets/Terminal.h
+++ b/app/src/UI/Widgets/Terminal.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <QTimer>
+#include <QColor>
 #include <QPalette>
 #include <QQuickPaintedItem>
 
@@ -73,6 +74,10 @@ class Terminal : public QQuickPaintedItem
              READ scrollOffsetY
              WRITE setScrollOffsetY
              NOTIFY scrollOffsetYChanged)
+  Q_PROPERTY(bool ansiColors
+             READ ansiColors
+             WRITE setAnsiColors
+             NOTIFY ansiColorsChanged)
   // clang-format on
 
 signals:
@@ -84,6 +89,7 @@ signals:
   void copyAvailableChanged();
   void scrollOffsetYChanged();
   void vt100EmulationChanged();
+  void ansiColorsChanged();
 
 public:
   Terminal(QQuickItem *parent = 0);
@@ -112,6 +118,7 @@ public:
   [[nodiscard]] const QPalette &palette() const;
 
   [[nodiscard]] bool autoscroll() const;
+  [[nodiscard]] bool ansiColors() const;
   [[nodiscard]] bool copyAvailable() const;
   [[nodiscard]] bool vt100emulation() const;
 
@@ -131,6 +138,7 @@ public slots:
   void setAutoscroll(const bool enabled);
   void setScrollOffsetY(const int offset);
   void setPalette(const QPalette &palette);
+  void setAnsiColors(const bool enabled);
   void setVt100Emulation(const bool enabled);
 
 private slots:
@@ -153,6 +161,7 @@ private:
   void setCursorPosition(const QPoint &position);
   void setCursorPosition(const int x, const int y);
   void replaceData(int x, int y, const QChar &byte);
+  void applyAnsiColor(int code);
 
 protected:
   bool shouldEndSelection(const QChar &c);
@@ -165,6 +174,7 @@ protected:
 private:
   QPalette m_palette;
   QStringList m_data;
+  QList<QList<QColor>> m_colorData;
 
   QFont m_font;
   int m_cWidth;
@@ -183,6 +193,7 @@ private:
 
   State m_state;
   bool m_autoscroll;
+  bool m_ansiColors;
   bool m_emulateVt100;
   bool m_cursorVisible;
   bool m_mouseTracking;
@@ -192,5 +203,6 @@ private:
   bool m_useFormatValueY;
 
   bool m_stateChanged;
+  QColor m_currentColor;
 };
 } // namespace Widgets


### PR DESCRIPTION
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/b57d7010-4e75-493e-b7d1-7583d0dce2cc" />


### This PR adds optional ANSI SGR color support to the terminal widget, allowing colored output from embedded devices and microcontrollers. 

New "ANSI Colors" checkbox next to the existing "Emulate VT-100" option
There's persistence between sessions. 
Zero overhead when disabled. No processing when the feature is turned off. 

### Implementation details
Per-character color storage using QList<QList<QColor>> parallel to existing text buffer
Color data is only allocated when the feature is enabled
Fast rendering path when colors are disabled (single setPen() call per line segment)
Color history is preserved when toggling the checkbox. Only cleared on terminal clear
