### PR TITLE
Console:Export - removed setConsumerEnabled call for non-commercial build

### DIFF
--- a/app/src/Console/Export.cpp
+++ b/app/src/Console/Export.cpp
@@ -273,11 +273,12 @@ void Console::Export::setExportEnabled(const bool enabled)
     Q_EMIT enabledChanged();
     return;
   }
+
+  setConsumerEnabled(false);
 #endif
 
   // Close file and disable export
   closeFile();
-  setConsumerEnabled(false);
   m_exportEnabled.store(false, std::memory_order_relaxed);
   m_settings.setValue("ConsoleExport", false);
   Q_EMIT enabledChanged();


### PR DESCRIPTION
`setConsumerEnabled` doesn't exist in `QObject`class which is the base class for Export in non-commercial build.
It causes compilation error when building GPLv3 version:

> Serial-Studio/app/src/Console/Export.cpp:280:3: error: use of undeclared identifier 'setConsumerEnabled'
>   280 |   setConsumerEnabled(false);
>       |   ^
> 1 error generated.
> make[2]: *** [app/CMakeFiles/Serial-Studio-GPL3.dir/src/Console/Export.cpp.o] Error 1
> make[2]: *** Waiting for unfinished jobs....
> make[1]: *** [app/CMakeFiles/Serial-Studio-GPL3.dir/all] Error 2
> make: *** [all] Error 2
> 