### PR TITLE
fullscreen bug fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,12 @@ cmake-build-*/
 
 # Other
 *.layout
+
+# json
+*.json
+
+# VS
+*.vs/
+
+# out 
+out/

--- a/app/qml/Widgets/SmartWindow.qml
+++ b/app/qml/Widgets/SmartWindow.qml
@@ -176,7 +176,9 @@ Window {
     if (root.visible) {
       if (root.visibility === Window.Maximized) {
         root.isMaximized = true
-      } else if (root.isMaximized && root.visibility !== Window.Minimized) {
+      } else if (root.isMaximized
+                 && root.visibility !== Window.Minimized
+                 && root.visibility !== Window.FullScreen) {
         root.isMaximized = false
         root.x = root.previousX
         root.y = root.previousY
@@ -195,7 +197,9 @@ Window {
     interval: 300
     repeat: false
     onTriggered: {
-      if (!root.isMaximized && root.visible && root.visibility !== Window.Maximized) {
+      if (!root.isMaximized && root.visible
+          && root.visibility !== Window.Maximized
+          && root.visibility !== Window.FullScreen) {
         root.previousX = root.x
         root.previousY = root.y
         root.previousWidth = root.width


### PR DESCRIPTION
Adjusted the fullscreen flow to prevent restoring or saving geometry during Window.FullScreen mode. Previously, this was forcing old positions/sizes, causing the window to become offset. This change is located in SmartWindow.qml:174-205, where geometry restoration and saving now ignore the fullscreen state.