### PR TITLE
Resize bug fixed

### DIFF
--- a/app/src/UI/WindowManager.cpp
+++ b/app/src/UI/WindowManager.cpp
@@ -359,7 +359,7 @@ UI::WindowManager::WindowManager(QQuickItem* parent)
 {
   // Configure item flags for mouse event handling
   setEnabled(true);
-  setAcceptHoverEvents(false);
+  setAcceptHoverEvents(true);
   setFlag(ItemHasContents, false);
   setFiltersChildMouseEvents(true);
   setAcceptedMouseButtons(Qt::AllButtons);
@@ -1257,7 +1257,8 @@ QRect UI::WindowManager::extractGeometry(QQuickItem* item) const
 /**
  * @brief Determines which edge or corner of a window is being hovered for resizing.
  */
-UI::WindowManager::ResizeEdge UI::WindowManager::detectResizeEdge(QQuickItem* target) const
+UI::WindowManager::ResizeEdge UI::WindowManager::detectResizeEdge(
+  QQuickItem* target, const QPointF& pos) const
 {
   // Only normal-state windows can be resized
   if (target->state() != "normal")
@@ -1265,7 +1266,7 @@ UI::WindowManager::ResizeEdge UI::WindowManager::detectResizeEdge(QQuickItem* ta
 
   // Map mouse position to window-local coordinates
   const int kResizeMargin = 8;
-  QPointF localPos        = target->mapFromItem(this, m_initialMousePos);
+  QPointF localPos        = target->mapFromItem(this, pos);
   const int x             = static_cast<int>(localPos.x());
   const int y             = static_cast<int>(localPos.y());
   const int w             = static_cast<int>(target->width());
@@ -1303,6 +1304,60 @@ UI::WindowManager::ResizeEdge UI::WindowManager::detectResizeEdge(QQuickItem* ta
     return ResizeEdge::Bottom;
 
   return ResizeEdge::None;
+}
+
+/**
+ * @brief Updates the cursor when hovering over resizable edges in manual layout mode.
+ */
+void UI::WindowManager::hoverMoveEvent(QHoverEvent* event)
+{
+  if (autoLayoutEnabled()) {
+    unsetCursor();
+    QQuickItem::hoverMoveEvent(event);
+    return;
+  }
+
+  const QPointF pos = event->position();
+  auto* target = getWindow(static_cast<int>(pos.x()), static_cast<int>(pos.y()));
+  if (!target || target->state() != "normal") {
+    unsetCursor();
+    QQuickItem::hoverMoveEvent(event);
+    return;
+  }
+
+  const ResizeEdge edge = detectResizeEdge(target, pos);
+  switch (edge) {
+    case ResizeEdge::Left:
+    case ResizeEdge::Right:
+      setCursor(Qt::SizeHorCursor);
+      break;
+    case ResizeEdge::Top:
+    case ResizeEdge::Bottom:
+      setCursor(Qt::SizeVerCursor);
+      break;
+    case ResizeEdge::TopRight:
+    case ResizeEdge::BottomLeft:
+      setCursor(Qt::SizeBDiagCursor);
+      break;
+    case ResizeEdge::TopLeft:
+    case ResizeEdge::BottomRight:
+      setCursor(Qt::SizeFDiagCursor);
+      break;
+    default:
+      unsetCursor();
+      break;
+  }
+
+  QQuickItem::hoverMoveEvent(event);
+}
+
+/**
+ * @brief Clears the resize cursor when the pointer leaves the canvas.
+ */
+void UI::WindowManager::hoverLeaveEvent(QHoverEvent* event)
+{
+  unsetCursor();
+  QQuickItem::hoverLeaveEvent(event);
 }
 
 /**
@@ -1585,7 +1640,7 @@ void UI::WindowManager::mousePressEvent(QMouseEvent* event)
 
   // Start resize or drag for normal-state windows
   if (m_focusedWindow->state() == "normal") {
-    m_resizeEdge = detectResizeEdge(m_focusedWindow);
+    m_resizeEdge = detectResizeEdge(m_focusedWindow, m_initialMousePos);
     if (m_resizeEdge != ResizeEdge::None && !autoLayoutEnabled()) {
       grabMouse();
       switch (m_resizeEdge) {

--- a/app/src/UI/WindowManager.cpp
+++ b/app/src/UI/WindowManager.cpp
@@ -346,6 +346,7 @@ UI::WindowManager::WindowManager(QQuickItem* parent)
   , m_layoutRestored(false)
   , m_autoLayoutEnabled(true)
   , m_userReordered(false)
+  , m_suppressGeometrySignal(false)
   , m_lastCanvasWidth(0)
   , m_lastCanvasHeight(0)
   , m_resizeEdge(ResizeEdge::None)
@@ -520,6 +521,8 @@ bool UI::WindowManager::restoreLayout(const QJsonObject& layout)
   }
 
   // Restore window positions in manual mode; stash unregistered ones for first paint
+  m_manualGeometries.clear();
+  m_manualMargins.clear();
   m_pendingGeometries.clear();
   if (!autoLayout && layout.contains("geometries")) {
     QJsonArray geometries = layout["geometries"].toArray();
@@ -541,6 +544,19 @@ bool UI::WindowManager::restoreLayout(const QJsonObject& layout)
         win->setY(geom.y());
         win->setWidth(geom.width());
         win->setHeight(geom.height());
+        storeManualGeometry(id, win);
+      } else {
+        m_manualGeometries.insert(id, geom);
+
+        const int canvasW = static_cast<int>(width());
+        const int canvasH = static_cast<int>(height());
+        if (canvasW > 0 && canvasH > 0) {
+          const int left   = qMax(0, geom.x());
+          const int top    = qMax(0, geom.y());
+          const int right  = qMax(0, canvasW - (geom.x() + geom.width()));
+          const int bottom = qMax(0, canvasH - (geom.y() + geom.height()));
+          m_manualMargins.insert(id, QMargins(left, top, right, bottom));
+        }
       }
 
       // Stash for late-arriving (or re-arriving) registrations
@@ -655,9 +671,12 @@ void UI::WindowManager::clear()
   m_focusedWindow        = nullptr;
   m_layoutRestored       = false;
   m_userReordered        = false;
+  m_suppressGeometrySignal = false;
   m_lastCanvasWidth      = 0;
   m_lastCanvasHeight     = 0;
   m_snapIndicatorVisible = false;
+  m_manualGeometries.clear();
+  m_manualMargins.clear();
   m_pendingGeometries.clear();
 
   // Re-enable auto layout if it was disabled
@@ -955,13 +974,46 @@ void UI::WindowManager::setAutoLayoutEnabled(const bool enabled)
     m_autoLayoutEnabled = enabled;
     Q_EMIT autoLayoutEnabledChanged();
 
+    if (enabled) {
+      m_manualGeometries.clear();
+      m_manualMargins.clear();
+    }
+
     // Restore maximized windows before re-tiling
     for (auto* win : std::as_const(m_windows))
       if (win->state() == "maximized")
         QMetaObject::invokeMethod(win, "restoreClicked");
 
     loadLayout();
+
+    if (!m_autoLayoutEnabled) {
+      for (auto it = m_windows.constBegin(); it != m_windows.constEnd(); ++it)
+        storeManualGeometry(it.key(), it.value());
+    }
   }
+}
+
+/**
+ * @brief Stores the preferred manual geometry and anchor margins for a window.
+ */
+void UI::WindowManager::storeManualGeometry(const int id, QQuickItem* item)
+{
+  if (!item)
+    return;
+
+  const QRect geom = extractGeometry(item);
+  m_manualGeometries.insert(id, geom);
+
+  const int canvasW = static_cast<int>(width());
+  const int canvasH = static_cast<int>(height());
+  if (canvasW <= 0 || canvasH <= 0)
+    return;
+
+  const int left   = qMax(0, geom.x());
+  const int top    = qMax(0, geom.y());
+  const int right  = qMax(0, canvasW - (geom.x() + geom.width()));
+  const int bottom = qMax(0, canvasH - (geom.y() + geom.height()));
+  m_manualMargins.insert(id, QMargins(left, top, right, bottom));
 }
 
 /**
@@ -973,26 +1025,30 @@ void UI::WindowManager::applyManualAnchors(
   if (previousWidth <= 0 || previousHeight <= 0 || newWidth <= 0 || newHeight <= 0)
     return;
 
-  for (auto* win : std::as_const(m_windows)) {
+  for (auto it = m_windows.constBegin(); it != m_windows.constEnd(); ++it) {
+    const int id = it.key();
+    auto* win    = it.value();
     if (!win || win->state() != "normal")
       continue;
 
-    const QRect geom = extractGeometry(win);
-    const int winW   = geom.width();
-    const int winH   = geom.height();
-    const int left   = geom.x();
-    const int top    = geom.y();
-    const int right  = previousWidth - (left + winW);
-    const int bottom = previousHeight - (top + winH);
+    if (!m_manualGeometries.contains(id) || !m_manualMargins.contains(id))
+      storeManualGeometry(id, win);
 
-    const bool anchorLeft = left <= right;
-    const bool anchorTop  = top <= bottom;
+    const QRect prefGeom   = m_manualGeometries.value(id, extractGeometry(win));
+    const QMargins margins = m_manualMargins.value(id, QMargins());
 
-    const int newX = anchorLeft ? left : newWidth - (right + winW);
-    const int newY = anchorTop ? top : newHeight - (bottom + winH);
+    const bool anchorLeft = margins.left() <= margins.right();
+    const bool anchorTop  = margins.top() <= margins.bottom();
+
+    const int newX = anchorLeft ? margins.left() :
+                                newWidth - (margins.right() + prefGeom.width());
+    const int newY = anchorTop ? margins.top() :
+                               newHeight - (margins.bottom() + prefGeom.height());
 
     win->setX(newX);
     win->setY(newY);
+    win->setWidth(prefGeom.width());
+    win->setHeight(prefGeom.height());
   }
 }
 
@@ -1079,7 +1135,8 @@ void UI::WindowManager::constrainWindows()
       win->setY(winY);
       win->setWidth(winW);
       win->setHeight(winH);
-      Q_EMIT geometryChanged(win);
+      if (!m_suppressGeometrySignal)
+        Q_EMIT geometryChanged(win);
     }
   }
 
@@ -1120,10 +1177,12 @@ void UI::WindowManager::triggerLayoutUpdate()
     if (sizeChanged && m_lastCanvasWidth > 0 && m_lastCanvasHeight > 0)
       applyManualAnchors(m_lastCanvasWidth, m_lastCanvasHeight, canvasW, canvasH);
 
+    m_suppressGeometrySignal = sizeChanged;
     if (hasUninitializedWindows && !m_layoutRestored)
       cascadeLayout();
     else
       constrainWindows();
+    m_suppressGeometrySignal = false;
   }
 
   if (sizeValid) {
@@ -1610,11 +1669,21 @@ void UI::WindowManager::mouseReleaseEvent(QMouseEvent* event)
       }
     }
 
-    if (m_dragWindow)
-      Q_EMIT geometryChanged(m_dragWindow);
+    if (m_dragWindow) {
+      const int id = getIdForWindow(m_dragWindow);
+      if (id >= 0)
+        storeManualGeometry(id, m_dragWindow);
 
-    else if (m_resizeWindow)
+      Q_EMIT geometryChanged(m_dragWindow);
+    }
+
+    else if (m_resizeWindow) {
+      const int id = getIdForWindow(m_resizeWindow);
+      if (id >= 0)
+        storeManualGeometry(id, m_resizeWindow);
+
       Q_EMIT geometryChanged(m_resizeWindow);
+    }
   }
 
   // Release mouse and reset cursor

--- a/app/src/UI/WindowManager.cpp
+++ b/app/src/UI/WindowManager.cpp
@@ -81,6 +81,39 @@ static std::optional<QRect> computeSnapRect(
 }
 
 /**
+ * @brief Returns manual anchor margins for a geometry within a canvas.
+ */
+static QMargins manualMarginsForGeometry(const QRect& geom, const int canvasW, const int canvasH)
+{
+  if (canvasW <= 0 || canvasH <= 0)
+    return QMargins();
+
+  const int left   = qMax(0, geom.x());
+  const int top    = qMax(0, geom.y());
+  const int right  = qMax(0, canvasW - (geom.x() + geom.width()));
+  const int bottom = qMax(0, canvasH - (geom.y() + geom.height()));
+  return QMargins(left, top, right, bottom);
+}
+
+/**
+ * @brief Returns the anchored geometry for a preferred size within a canvas.
+ */
+static QRect anchoredGeometry(
+  const QRect& preferred, const QMargins& margins, const int canvasW, const int canvasH)
+{
+  if (canvasW <= 0 || canvasH <= 0)
+    return preferred;
+
+  const bool anchorLeft = margins.left() <= margins.right();
+  const bool anchorTop  = margins.top() <= margins.bottom();
+  const int x           = anchorLeft ? margins.left() :
+                                      canvasW - (margins.right() + preferred.width());
+  const int y           = anchorTop ? margins.top() :
+                                     canvasH - (margins.bottom() + preferred.height());
+  return QRect(x, y, preferred.width(), preferred.height());
+}
+
+/**
  * @brief Returns true if any tracked window is currently in the maximized state.
  */
 static bool anyWindowMaximized(const QMap<int, QQuickItem*>& windows)
@@ -543,30 +576,31 @@ bool UI::WindowManager::restoreLayout(const QJsonObject& layout)
       const int w = static_cast<int>(winGeom["width"].toDouble(200));
       const int h = static_cast<int>(winGeom["height"].toDouble(150));
       const QRect geom(x, y, w, h);
+      const int canvasW      = static_cast<int>(width());
+      const int canvasH      = static_cast<int>(height());
+      const int marginCanvasW = savedCanvasW > 0 ? savedCanvasW : canvasW;
+      const int marginCanvasH = savedCanvasH > 0 ? savedCanvasH : canvasH;
+      const QMargins margins = manualMarginsForGeometry(geom, marginCanvasW, marginCanvasH);
+      const QRect anchored   = anchoredGeometry(geom, margins, canvasW, canvasH);
 
       auto* win = m_windows.value(id);
       if (win) {
-        win->setX(geom.x());
-        win->setY(geom.y());
-        win->setWidth(geom.width());
-        win->setHeight(geom.height());
-        storeManualGeometry(id, win, savedCanvasW, savedCanvasH);
-      } else {
-        m_manualGeometries.insert(id, geom);
+        win->setX(anchored.x());
+        win->setY(anchored.y());
+        win->setWidth(anchored.width());
+        win->setHeight(anchored.height());
+      }
 
-        const int canvasW = savedCanvasW > 0 ? savedCanvasW : static_cast<int>(width());
-        const int canvasH = savedCanvasH > 0 ? savedCanvasH : static_cast<int>(height());
-        if (canvasW > 0 && canvasH > 0) {
-          const int left   = qMax(0, geom.x());
-          const int top    = qMax(0, geom.y());
-          const int right  = qMax(0, canvasW - (geom.x() + geom.width()));
-          const int bottom = qMax(0, canvasH - (geom.y() + geom.height()));
-          m_manualMargins.insert(id, QMargins(left, top, right, bottom));
-        }
+      m_manualGeometries.insert(id, geom);
+      m_manualMargins.insert(id, margins);
+
+      if (!win) {
+        m_pendingGeometries.insert(id, anchored);
+        continue;
       }
 
       // Stash for late-arriving (or re-arriving) registrations
-      m_pendingGeometries.insert(id, geom);
+      m_pendingGeometries.insert(id, anchored);
     }
 
     constrainWindows();
@@ -1016,11 +1050,7 @@ void UI::WindowManager::storeManualGeometry(
   if (canvasW <= 0 || canvasH <= 0)
     return;
 
-  const int left   = qMax(0, geom.x());
-  const int top    = qMax(0, geom.y());
-  const int right  = qMax(0, canvasW - (geom.x() + geom.width()));
-  const int bottom = qMax(0, canvasH - (geom.y() + geom.height()));
-  m_manualMargins.insert(id, QMargins(left, top, right, bottom));
+  m_manualMargins.insert(id, manualMarginsForGeometry(geom, canvasW, canvasH));
 }
 
 /**
@@ -1043,19 +1073,12 @@ void UI::WindowManager::applyManualAnchors(
 
     const QRect prefGeom   = m_manualGeometries.value(id, extractGeometry(win));
     const QMargins margins = m_manualMargins.value(id, QMargins());
+    const QRect anchored   = anchoredGeometry(prefGeom, margins, newWidth, newHeight);
 
-    const bool anchorLeft = margins.left() <= margins.right();
-    const bool anchorTop  = margins.top() <= margins.bottom();
-
-    const int newX = anchorLeft ? margins.left() :
-                                newWidth - (margins.right() + prefGeom.width());
-    const int newY = anchorTop ? margins.top() :
-                               newHeight - (margins.bottom() + prefGeom.height());
-
-    win->setX(newX);
-    win->setY(newY);
-    win->setWidth(prefGeom.width());
-    win->setHeight(prefGeom.height());
+    win->setX(anchored.x());
+    win->setY(anchored.y());
+    win->setWidth(anchored.width());
+    win->setHeight(anchored.height());
   }
 }
 

--- a/app/src/UI/WindowManager.cpp
+++ b/app/src/UI/WindowManager.cpp
@@ -346,6 +346,8 @@ UI::WindowManager::WindowManager(QQuickItem* parent)
   , m_layoutRestored(false)
   , m_autoLayoutEnabled(true)
   , m_userReordered(false)
+  , m_lastCanvasWidth(0)
+  , m_lastCanvasHeight(0)
   , m_resizeEdge(ResizeEdge::None)
   , m_snapIndicatorVisible(false)
   , m_taskbar(nullptr)
@@ -653,6 +655,8 @@ void UI::WindowManager::clear()
   m_focusedWindow        = nullptr;
   m_layoutRestored       = false;
   m_userReordered        = false;
+  m_lastCanvasWidth      = 0;
+  m_lastCanvasHeight     = 0;
   m_snapIndicatorVisible = false;
   m_pendingGeometries.clear();
 
@@ -961,6 +965,38 @@ void UI::WindowManager::setAutoLayoutEnabled(const bool enabled)
 }
 
 /**
+ * @brief Repositions manual-layout windows to preserve edge anchoring on resize.
+ */
+void UI::WindowManager::applyManualAnchors(
+  const int previousWidth, const int previousHeight, const int newWidth, const int newHeight)
+{
+  if (previousWidth <= 0 || previousHeight <= 0 || newWidth <= 0 || newHeight <= 0)
+    return;
+
+  for (auto* win : std::as_const(m_windows)) {
+    if (!win || win->state() != "normal")
+      continue;
+
+    const QRect geom = extractGeometry(win);
+    const int winW   = geom.width();
+    const int winH   = geom.height();
+    const int left   = geom.x();
+    const int top    = geom.y();
+    const int right  = previousWidth - (left + winW);
+    const int bottom = previousHeight - (top + winH);
+
+    const bool anchorLeft = left <= right;
+    const bool anchorTop  = top <= bottom;
+
+    const int newX = anchorLeft ? left : newWidth - (right + winW);
+    const int newY = anchorTop ? top : newHeight - (bottom + winH);
+
+    win->setX(newX);
+    win->setY(newY);
+  }
+}
+
+/**
  * @brief Constrains all windows to fit within the current canvas bounds.
  */
 void UI::WindowManager::constrainWindows()
@@ -1061,6 +1097,12 @@ void UI::WindowManager::constrainWindows()
  */
 void UI::WindowManager::triggerLayoutUpdate()
 {
+  const int canvasW      = static_cast<int>(width());
+  const int canvasH      = static_cast<int>(height());
+  const bool sizeValid   = canvasW > 0 && canvasH > 0;
+  const bool sizeChanged = sizeValid
+                         && (canvasW != m_lastCanvasWidth || canvasH != m_lastCanvasHeight);
+
   // Auto-layout mode: re-tile all windows
   if (autoLayoutEnabled())
     autoLayout();
@@ -1075,10 +1117,18 @@ void UI::WindowManager::triggerLayoutUpdate()
       }
     }
 
+    if (sizeChanged && m_lastCanvasWidth > 0 && m_lastCanvasHeight > 0)
+      applyManualAnchors(m_lastCanvasWidth, m_lastCanvasHeight, canvasW, canvasH);
+
     if (hasUninitializedWindows && !m_layoutRestored)
       cascadeLayout();
     else
       constrainWindows();
+  }
+
+  if (sizeValid) {
+    m_lastCanvasWidth  = canvasW;
+    m_lastCanvasHeight = canvasH;
   }
 }
 

--- a/app/src/UI/WindowManager.cpp
+++ b/app/src/UI/WindowManager.cpp
@@ -478,6 +478,10 @@ QJsonObject UI::WindowManager::serializeLayout() const
 
   layout["geometries"] = geometries;
 
+  // Canvas snapshot (Pro notice/actions panel can change available space)
+  layout["canvasWidth"] = static_cast<int>(width());
+  layout["canvasHeight"] = static_cast<int>(height());
+
   // Save window order and layout mode
   QJsonArray orderArray;
   for (int id : m_windowOrder)
@@ -500,6 +504,8 @@ bool UI::WindowManager::restoreLayout(const QJsonObject& layout)
     return false;
 
   bool autoLayout = layout["autoLayout"].toBool(true);
+  const int savedCanvasW = layout["canvasWidth"].toInt(0);
+  const int savedCanvasH = layout["canvasHeight"].toInt(0);
   m_userReordered = layout["userReordered"].toBool(false);
 
   // Restore window order, appending any unsaved windows at the end
@@ -544,12 +550,12 @@ bool UI::WindowManager::restoreLayout(const QJsonObject& layout)
         win->setY(geom.y());
         win->setWidth(geom.width());
         win->setHeight(geom.height());
-        storeManualGeometry(id, win);
+        storeManualGeometry(id, win, savedCanvasW, savedCanvasH);
       } else {
         m_manualGeometries.insert(id, geom);
 
-        const int canvasW = static_cast<int>(width());
-        const int canvasH = static_cast<int>(height());
+        const int canvasW = savedCanvasW > 0 ? savedCanvasW : static_cast<int>(width());
+        const int canvasH = savedCanvasH > 0 ? savedCanvasH : static_cast<int>(height());
         if (canvasW > 0 && canvasH > 0) {
           const int left   = qMax(0, geom.x());
           const int top    = qMax(0, geom.y());
@@ -996,7 +1002,8 @@ void UI::WindowManager::setAutoLayoutEnabled(const bool enabled)
 /**
  * @brief Stores the preferred manual geometry and anchor margins for a window.
  */
-void UI::WindowManager::storeManualGeometry(const int id, QQuickItem* item)
+void UI::WindowManager::storeManualGeometry(
+  const int id, QQuickItem* item, const int canvasWidth, const int canvasHeight)
 {
   if (!item)
     return;
@@ -1004,8 +1011,8 @@ void UI::WindowManager::storeManualGeometry(const int id, QQuickItem* item)
   const QRect geom = extractGeometry(item);
   m_manualGeometries.insert(id, geom);
 
-  const int canvasW = static_cast<int>(width());
-  const int canvasH = static_cast<int>(height());
+  const int canvasW = canvasWidth > 0 ? canvasWidth : static_cast<int>(width());
+  const int canvasH = canvasHeight > 0 ? canvasHeight : static_cast<int>(height());
   if (canvasW <= 0 || canvasH <= 0)
     return;
 

--- a/app/src/UI/WindowManager.h
+++ b/app/src/UI/WindowManager.h
@@ -126,7 +126,7 @@ private:
   void handleDragMove(QMouseEvent* event, const QPoint& delta);
   void handleResizeMove(QMouseEvent* event, const QPoint& delta);
   void applyManualAnchors(int previousWidth, int previousHeight, int newWidth, int newHeight);
-  void storeManualGeometry(int id, QQuickItem* item);
+  void storeManualGeometry(int id, QQuickItem* item, int canvasWidth = -1, int canvasHeight = -1);
   void updateManualSnapIndicator(int newX, int newY, int w, int h, int canvasW, int canvasH);
   [[nodiscard]] QRect computeResizedGeometry(const QPoint& delta) const;
 

--- a/app/src/UI/WindowManager.h
+++ b/app/src/UI/WindowManager.h
@@ -124,6 +124,7 @@ private:
 
   void handleDragMove(QMouseEvent* event, const QPoint& delta);
   void handleResizeMove(QMouseEvent* event, const QPoint& delta);
+  void applyManualAnchors(int previousWidth, int previousHeight, int newWidth, int newHeight);
   void updateManualSnapIndicator(int newX, int newY, int w, int h, int canvasW, int canvasH);
   [[nodiscard]] QRect computeResizedGeometry(const QPoint& delta) const;
 
@@ -138,6 +139,8 @@ private:
   bool m_layoutRestored;
   bool m_autoLayoutEnabled;
   bool m_userReordered;
+  int m_lastCanvasWidth;
+  int m_lastCanvasHeight;
   QString m_backgroundImage;
 
   QVector<int> m_windowOrder;

--- a/app/src/UI/WindowManager.h
+++ b/app/src/UI/WindowManager.h
@@ -120,7 +120,7 @@ private:
   [[nodiscard]] QQuickItem* findOverlapTarget(const QRect& dragRect) const;
 
   [[nodiscard]] QRect extractGeometry(QQuickItem* item) const;
-  [[nodiscard]] ResizeEdge detectResizeEdge(QQuickItem* target) const;
+  [[nodiscard]] ResizeEdge detectResizeEdge(QQuickItem* target, const QPointF& pos) const;
   QQuickItem* getWindow(const int x, const int y) const;
 
   void handleDragMove(QMouseEvent* event, const QPoint& delta);
@@ -131,6 +131,8 @@ private:
   [[nodiscard]] QRect computeResizedGeometry(const QPoint& delta) const;
 
 protected:
+  void hoverLeaveEvent(QHoverEvent* event) override;
+  void hoverMoveEvent(QHoverEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;
   void mousePressEvent(QMouseEvent* event) override;
   void mouseReleaseEvent(QMouseEvent* event) override;

--- a/app/src/UI/WindowManager.h
+++ b/app/src/UI/WindowManager.h
@@ -23,6 +23,7 @@
 
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QMargins>
 #include <QMap>
 #include <QObject>
 #include <QQuickItem>
@@ -125,6 +126,7 @@ private:
   void handleDragMove(QMouseEvent* event, const QPoint& delta);
   void handleResizeMove(QMouseEvent* event, const QPoint& delta);
   void applyManualAnchors(int previousWidth, int previousHeight, int newWidth, int newHeight);
+  void storeManualGeometry(int id, QQuickItem* item);
   void updateManualSnapIndicator(int newX, int newY, int w, int h, int canvasW, int canvasH);
   [[nodiscard]] QRect computeResizedGeometry(const QPoint& delta) const;
 
@@ -139,6 +141,7 @@ private:
   bool m_layoutRestored;
   bool m_autoLayoutEnabled;
   bool m_userReordered;
+  bool m_suppressGeometrySignal;
   int m_lastCanvasWidth;
   int m_lastCanvasHeight;
   QString m_backgroundImage;
@@ -146,6 +149,8 @@ private:
   QVector<int> m_windowOrder;
   QMap<int, QQuickItem*> m_windows;
   QMap<QQuickItem*, int> m_windowZ;
+  QMap<int, QRect> m_manualGeometries;
+  QMap<int, QMargins> m_manualMargins;
   QMap<int, QRect> m_pendingGeometries;
 
   ResizeEdge m_resizeEdge;


### PR DESCRIPTION
When auto-layout was disabled, resizing the canvas caused the windows to lose their screen anchoring. Now, when resizing the screen, the windows remain anchored to the defined configuration.

It also takes the canvas size into account, so when the 'Pro' message appears or the screen is resized, the layout doesn't break.