### PR TITLE
Resize bug fixed

### DIFF
--- a/app/src/UI/WindowManager.cpp
+++ b/app/src/UI/WindowManager.cpp
@@ -1092,10 +1092,22 @@ void UI::WindowManager::applyManualAnchors(const int newWidth, const int newHeig
   if (newWidth <= 0 || newHeight <= 0)
     return;
 
-  const int refWidth  = m_manualCanvasWidth > 0 ? m_manualCanvasWidth : newWidth;
-  const int refHeight = m_manualCanvasHeight > 0 ? m_manualCanvasHeight : newHeight;
-  const double scaleX = refWidth > 0 ? qMin(1.0, double(newWidth) / double(refWidth)) : 1.0;
-  const double scaleY = refHeight > 0 ? qMin(1.0, double(newHeight) / double(refHeight)) : 1.0;
+  int refWidth  = m_manualCanvasWidth > 0 ? m_manualCanvasWidth : newWidth;
+  int refHeight = m_manualCanvasHeight > 0 ? m_manualCanvasHeight : newHeight;
+
+  if (m_manualCanvasWidth <= 0 && m_lastCanvasWidth > 0)
+    refWidth = m_lastCanvasWidth;
+
+  if (m_manualCanvasHeight <= 0 && m_lastCanvasHeight > 0)
+    refHeight = m_lastCanvasHeight;
+
+  if (m_manualCanvasWidth <= 0 && refWidth > 0)
+    m_manualCanvasWidth = refWidth;
+
+  if (m_manualCanvasHeight <= 0 && refHeight > 0)
+    m_manualCanvasHeight = refHeight;
+  const double scaleX = refWidth > 0 ? double(newWidth) / double(refWidth) : 1.0;
+  const double scaleY = refHeight > 0 ? double(newHeight) / double(refHeight) : 1.0;
 
   for (auto it = m_windows.constBegin(); it != m_windows.constEnd(); ++it) {
     const int id = it.key();
@@ -1108,8 +1120,8 @@ void UI::WindowManager::applyManualAnchors(const int newWidth, const int newHeig
 
     const QRect prefGeom   = m_manualGeometries.value(id, extractGeometry(win));
     const QMargins margins = m_manualMargins.value(id, QMargins());
-    const int scaledW      = qMax(1, qRound(prefGeom.width() * scaleX));
-    const int scaledH      = qMax(1, qRound(prefGeom.height() * scaleY));
+    const int scaledW      = qRound(prefGeom.width() * scaleX);
+    const int scaledH      = qRound(prefGeom.height() * scaleY);
     const QMargins scaledMargins(qRound(margins.left() * scaleX),
                                  qRound(margins.top() * scaleY),
                                  qRound(margins.right() * scaleX),
@@ -1267,6 +1279,17 @@ void UI::WindowManager::triggerLayoutUpdate()
       if (win && !win->isVisible() && (win->state() == "normal" || win->state() == "maximized")) {
         hasUninitializedWindows = true;
         break;
+      }
+    }
+
+    if (sizeChanged && m_lastCanvasWidth > 0 && m_lastCanvasHeight > 0) {
+      for (auto it = m_windows.constBegin(); it != m_windows.constEnd(); ++it) {
+        const int id = it.key();
+        auto* win    = it.value();
+        if (!win || win->state() != "normal")
+          continue;
+
+        storeManualGeometry(id, win, m_lastCanvasWidth, m_lastCanvasHeight);
       }
     }
 

--- a/app/src/UI/WindowManager.cpp
+++ b/app/src/UI/WindowManager.cpp
@@ -1106,6 +1106,7 @@ void UI::WindowManager::applyManualAnchors(const int newWidth, const int newHeig
 
   if (m_manualCanvasHeight <= 0 && refHeight > 0)
     m_manualCanvasHeight = refHeight;
+    
   const double scaleX = refWidth > 0 ? double(newWidth) / double(refWidth) : 1.0;
   const double scaleY = refHeight > 0 ? double(newHeight) / double(refHeight) : 1.0;
 

--- a/app/src/UI/WindowManager.cpp
+++ b/app/src/UI/WindowManager.cpp
@@ -1120,12 +1120,16 @@ void UI::WindowManager::applyManualAnchors(const int newWidth, const int newHeig
 
     const QRect prefGeom   = m_manualGeometries.value(id, extractGeometry(win));
     const QMargins margins = m_manualMargins.value(id, QMargins());
-    const int scaledW      = qRound(prefGeom.width() * scaleX);
-    const int scaledH      = qRound(prefGeom.height() * scaleY);
+    int scaledW            = qRound(prefGeom.width() * scaleX);
+    int scaledH            = qRound(prefGeom.height() * scaleY);
     const QMargins scaledMargins(qRound(margins.left() * scaleX),
-                                 qRound(margins.top() * scaleY),
-                                 qRound(margins.right() * scaleX),
-                                 qRound(margins.bottom() * scaleY));
+                   qRound(margins.top() * scaleY),
+                   qRound(margins.right() * scaleX),
+                   qRound(margins.bottom() * scaleY));
+    const int maxW = qMax(0, newWidth - scaledMargins.left() - scaledMargins.right());
+    const int maxH = qMax(0, newHeight - scaledMargins.top() - scaledMargins.bottom());
+    scaledW = qMin(scaledW, maxW);
+    scaledH = qMin(scaledH, maxH);
     const QRect scaledPref(0, 0, scaledW, scaledH);
     const QRect anchored = anchoredGeometry(scaledPref, scaledMargins, newWidth, newHeight);
 
@@ -1279,17 +1283,6 @@ void UI::WindowManager::triggerLayoutUpdate()
       if (win && !win->isVisible() && (win->state() == "normal" || win->state() == "maximized")) {
         hasUninitializedWindows = true;
         break;
-      }
-    }
-
-    if (sizeChanged && m_lastCanvasWidth > 0 && m_lastCanvasHeight > 0) {
-      for (auto it = m_windows.constBegin(); it != m_windows.constEnd(); ++it) {
-        const int id = it.key();
-        auto* win    = it.value();
-        if (!win || win->state() != "normal")
-          continue;
-
-        storeManualGeometry(id, win, m_lastCanvasWidth, m_lastCanvasHeight);
       }
     }
 


### PR DESCRIPTION
I've improved the previous implementation of the manual scaling logic. It formerly only worked when scaling down from fullscreen; it now correctly handles the reverse transition (scaling up to fullscreen) by ensuring a valid reference is always used.