### PR TITLE
chore: scrub leaked refactor notes from example READMEs, bump upload-…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -282,7 +282,7 @@ jobs:
 
     - name: '🛡 Upload deglyph SARIF'
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: deglyph.sarif
         category: deglyph-linux-x64
@@ -565,7 +565,7 @@ jobs:
 
     - name: '🛡 Upload deglyph SARIF'
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: deglyph.sarif
         category: deglyph-linux-arm64
@@ -834,7 +834,7 @@ jobs:
 
     - name: '🛡 Upload deglyph SARIF'
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: deglyph.sarif
         category: deglyph-macos
@@ -1067,7 +1067,7 @@ jobs:
 
     - name: '🛡 Upload deglyph SARIF'
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: deglyph.sarif
         category: deglyph-windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,7 +241,7 @@ jobs:
 
     - name: '🛡 Upload deglyph SARIF'
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: deglyph.sarif
         category: deglyph-test-linux

--- a/examples/ANSI Color Test/README.md
+++ b/examples/ANSI Color Test/README.md
@@ -194,7 +194,6 @@ You can modify `test_ansi_colors.py` to:
 
 Serial Studio's ANSI color implementation:
 
-- **Performance**: Lock-free data paths with zero-copy dashboard updates
 - **Color accuracy**: Full 24-bit RGB support (16.7M colors)
 - **Standards compliance**: VT-100/ANSI X3.64 escape sequences
 - **Background rendering**: Separate passes for backgrounds and text to prevent overlap

--- a/examples/IMU Simulator/README.md
+++ b/examples/IMU Simulator/README.md
@@ -167,7 +167,7 @@ function parse(frame) {
 
 - **Parsing overhead.** Single JavaScript call per packet.
 - **Memory.** One allocation for the multi-frame list.
-- **Dashboard updates.** Zero-copy via const reference (preserved).
+- **Dashboard updates.** Zero-copy via const reference.
 - **Throughput.** Tested with 120 samples/packet at 10 Hz = 1200 frames/sec.
 
 ## License


### PR DESCRIPTION
…sarif to v4

Remove an internal '(preserved)' edit annotation and an irrelevant lock-free/zero-copy performance bullet that had leaked into the IMU Simulator and ANSI Color Test example READMEs. Bump all five github/codeql-action/upload-sarif usages from v3 to v4 to clear the deprecation warnings.