### PR TITLE
fix: correct Faled→Failed typo in MDF error message

### DIFF
--- a/lib/mdflib/mdflib/src/mdf3writer.cpp
+++ b/lib/mdflib/mdflib/src/mdf3writer.cpp
@@ -55,7 +55,7 @@ bool Mdf3Writer::PrepareForWriting() {
       if (auto* cg3 = dynamic_cast<Cg3Block*>(channel_group);
           cg3 != nullptr) {
         if (const bool prep = cg3->PrepareForWriting(); !prep ) {
-          MDF_ERROR() << "Faled to prepare for writing.";
+          MDF_ERROR() << "Failed to prepare for writing.";
           return false;
         }
       }


### PR DESCRIPTION
Corrects the typo `Faled` → `Failed` in the MDF error message in mdf3writer.cpp.