### PR TITLE
fix assistant memory commercial guard

### DIFF
--- a/app/src/API/Handlers/AssistantHandler.cpp
+++ b/app/src/API/Handlers/AssistantHandler.cpp
@@ -983,9 +983,14 @@ API::CommandResponse API::Handlers::AssistantHandler::listCheckpoints(const QStr
   return CommandResponse::makeSuccess(id, result);
 }
 
+#ifdef BUILD_COMMERCIAL
 /**
  * @brief Queue a memory proposal for user confirmation; deliberately side-effect-free --
  *        nothing persists unless the user clicks the confirmation chip in the chat.
+ *
+ *        Commercial-only: AI::MemoryStore lives in src/AI/, which is only compiled when
+ *        BUILD_COMMERCIAL=ON. Referencing it from an unconditional translation unit
+ *        breaks the link in GPL3-only builds (BUILD_GPL3=ON forces BUILD_COMMERCIAL=OFF).
  */
 API::CommandResponse API::Handlers::AssistantHandler::memoryPropose(const QString& id,
                                                                     const QJsonObject& params)
@@ -1013,6 +1018,7 @@ API::CommandResponse API::Handlers::AssistantHandler::memoryPropose(const QStrin
     QStringLiteral("Proposal shown to the user for confirmation; nothing has been stored.");
   return CommandResponse::makeSuccess(id, result);
 }
+#endif
 
 //--------------------------------------------------------------------------------------------------
 // Registration
@@ -1295,8 +1301,12 @@ void API::Handlers::AssistantHandler::registerCheckpointCommands()
     &API::Handlers::AssistantHandler::projectBulkApply);
 }
 
+#ifdef BUILD_COMMERCIAL
 /**
- * @brief Register the consent-gated memory-proposal command.
+ * @brief Register the consent-gated memory-proposal command (Commercial).
+ *
+ *        Guarded together with memoryPropose(): the handler itself depends on
+ *        AI::MemoryStore, which only exists in commercial builds.
  */
 void API::Handlers::AssistantHandler::registerMemoryCommands()
 {
@@ -1321,6 +1331,7 @@ void API::Handlers::AssistantHandler::registerMemoryCommands()
       {}),
     &API::Handlers::AssistantHandler::memoryPropose);
 }
+#endif
 
 /**
  * @brief Wire every assistant.* command into CommandRegistry.
@@ -1330,5 +1341,7 @@ void API::Handlers::AssistantHandler::registerCommands()
   registerResolverCommands();
   registerEditCommands();
   registerCheckpointCommands();
+#ifdef BUILD_COMMERCIAL
   registerMemoryCommands();
+#endif
 }

--- a/app/src/API/Handlers/AssistantHandler.h
+++ b/app/src/API/Handlers/AssistantHandler.h
@@ -37,7 +37,9 @@ private:
   static void registerResolverCommands();
   static void registerEditCommands();
   static void registerCheckpointCommands();
+#ifdef BUILD_COMMERCIAL
   static void registerMemoryCommands();
+#endif
 
   static CommandResponse snapshot(const QString& id, const QJsonObject& params);
   static CommandResponse datasetResolve(const QString& id, const QJsonObject& params);
@@ -51,7 +53,9 @@ private:
   static CommandResponse checkpoint(const QString& id, const QJsonObject& params);
   static CommandResponse restore(const QString& id, const QJsonObject& params);
   static CommandResponse listCheckpoints(const QString& id, const QJsonObject& params);
+#ifdef BUILD_COMMERCIAL
   static CommandResponse memoryPropose(const QString& id, const QJsonObject& params);
+#endif
 };
 
 }  // namespace Handlers


### PR DESCRIPTION
## What this changes

A compilation error occurred when preparing to update [AUR serial-studio](https://aur.archlinux.org/packages/serial-studio)  to 4.1.0. The diary is as follows. Compilation passed after repair.

```bash
/usr/lib/libabsl_source_location.so.2608.0.0  /usr/lib/libssl.so  /usr/lib/libcrypto.so  /usr/lib/libaddress_sorting.so.56.0.0  -ldl  -lm  -lrt  -lsystemd  /usr/lib/libsystemd.so && :
/usr/bin/ld: app/CMakeFiles/serial-studio-gpl3.dir/src/API/Handlers/AssistantHandler.cpp.o: in function `API::Handlers::AssistantHandler::memoryPropose(QString const&, QJsonObject const&)':
/usr/src/debug/serial-studio/serial-studio/app/src/API/Handlers/AssistantHandler.cpp:996:(.text+0x90b7): undefined reference to `AI::MemoryStore::categories()'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
==> ERROR: A failure occurred in build().
    Aborting...
```

## Related issue

## How it was tested

```bash
[972/975] Building CXX object app/CMakeFiles/serial-studio-gpl3.dir/.rcc/qmlcache/serial-studio-gpl3_qml_Widgets_TaskbarButton_qml.cpp.o
<command-line>: warning: ‘_FORTIFY_SOURCE’ redefined
<command-line>: note: this is the location of the previous definition
[973/975] Building CXX object app/CMakeFiles/serial-studio-gpl3.dir/.rcc/qmlcache/serial-studio-gpl3_qml_Widgets_MarkdownWebView_qml.cpp.o
<command-line>: warning: ‘_FORTIFY_SOURCE’ redefined
<command-line>: note: this is the location of the previous definition
[974/975] Building CXX object app/CMakeFiles/serial-studio-gpl3.dir/.rcc/qmlcache/serial-studio-gpl3_qml_Widgets_Dashboard_WebEngineSurface_qml.cpp.o
<command-line>: warning: ‘_FORTIFY_SOURCE’ redefined
<command-line>: note: this is the location of the previous definition
[975/975] Linking CXX executable app/serial-studio-gpl3
==> Entering fakeroot environment...
==> Starting package()...
install: creating directory '/build/serial-studio/pkg/serial-studio/usr'
install: creating directory '/build/serial-studio/pkg/serial-studio/usr/share'
install: creating directory '/build/serial-studio/pkg/serial-studio/usr/share/licenses'
```

## Checklist

- [x] I read [CONTRIBUTING.md](https://github.com/Serial-Studio/.github/blob/main/CONTRIBUTING.md)
      and agree to the Contributor License Agreement
- [x] The change follows the code style of the repository, and its verification scripts pass
- [ ] New public APIs are documented
- [x] CI passes
